### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def new
+
     @item = Item.new
   end
 
@@ -25,6 +26,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :text, :category, :status, :shipping_charges, :shipping_origin, :days_until_shipping, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :category_id, :status_id, :shipping_charges_id, :shipping_origin_id, :days_until_shipping_id, :price, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,6 @@ class ItemsController < ApplicationController
   end
 
   def new
-
     @item = Item.new
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,17 +1,21 @@
 class Item < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user
+  belongs_to_active_hash :category
+  belongs_to_active_hash :status
+  belongs_to_active_hash :shipping_charges
+  belongs_to_active_hash :shipping_origin
+  belongs_to_active_hash :days_until_shipping
   has_one_attached :image
 
-  with_options presence: true do
-    validates :name
-    validates :text
-    validates :category,            numericality: { other_than: 0 }
-    validates :status,              numericality: { other_than: 0 }
-    validates :shipping_charges,    numericality: { other_than: 0 }
-    validates :shipping_origin,     numericality: { other_than: 0 }
-    validates :days_until_shipping, numericality: { other_than: 0 }
-    validates :price,               numericality: { only_integer: true, message: 'は半角数字で入力してください' }
-    validates :image
-  end
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
+  validates :name, :text, :category, :status, :shipping_charges, 
+            :shipping_origin, :days_until_shipping, :price, :image, presence: true 
+
+  validates :category_id,            numericality: { other_than: 0 }
+  validates :status_id,              numericality: { other_than: 0 }
+  validates :shipping_charges_id,    numericality: { other_than: 0 }
+  validates :shipping_origin_id,     numericality: { other_than: 0 }
+  validates :days_until_shipping_id, numericality: { other_than: 0 }
+  validates :price,                  numericality: { only_integer: true, message: 'は半角数字で入力してください' }
+  validates :price,                  numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,8 +8,8 @@ class Item < ApplicationRecord
   belongs_to_active_hash :days_until_shipping
   has_one_attached :image
 
-  validates :name, :text, :category, :status, :shipping_charges, 
-            :shipping_origin, :days_until_shipping, :price, :image, presence: true 
+  validates :name, :text, :category, :status, :shipping_charges,
+            :shipping_origin, :days_until_shipping, :price, :image, presence: true
 
   validates :category_id,            numericality: { other_than: 0 }
   validates :status_id,              numericality: { other_than: 0 }

--- a/app/models/shipping_origin.rb
+++ b/app/models/shipping_origin.rb
@@ -1,6 +1,6 @@
 class ShippingOrigin < ActiveHash::Base
   self.data = [
-    { id: 0, name: '--' }, {id: 1, name: '北海道'}, {id: 2, name: '青森県'},
+    { id: 0, name: '--' }, { id: 1, name: '北海道'}, {id: 2, name: '青森県'},
     {id: 3, name: '岩手県'}, {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'},
     {id: 6, name: '山形県'}, {id: 7, name: '福島県'}, {id: 8, name: '茨城県'},
     {id: 9, name: '栃木県'}, {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'},

--- a/app/models/shipping_origin.rb
+++ b/app/models/shipping_origin.rb
@@ -1,6 +1,6 @@
 class ShippingOrigin < ActiveHash::Base
   self.data = [
-    { id: 0, name: '--' }, { id: 1, name: '北海道'}, {id: 2, name: '青森県'},
+    { id: 0, name: '--' }, { id: 1, name: '北海道' }, {id: 2, name: '青森県'},
     {id: 3, name: '岩手県'}, {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'},
     {id: 6, name: '山形県'}, {id: 7, name: '福島県'}, {id: 8, name: '茨城県'},
     {id: 9, name: '栃木県'}, {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'},

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -48,12 +48,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -69,17 +69,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges, ShippingCharges.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charges_id, ShippingCharges.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_origin, ShippingOrigin.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_origin_id, ShippingOrigin.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_until_shipping, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,35 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       ¥ <%= @item.price %> 
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if current_user == @item.user %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if current_user != @item.user %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,33 +35,33 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charges.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_origin.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
   
 end

--- a/db/migrate/20200913032529_create_items.rb
+++ b/db/migrate/20200913032529_create_items.rb
@@ -1,15 +1,15 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.string :name,                 null: false
-      t.text :text,                   null: false
-      t.integer :category,            null: false
-      t.integer :status,              null: false
-      t.integer :shipping_charges,    null: false
-      t.integer :shipping_origin,     null: false
-      t.integer :days_until_shipping, null: false
-      t.integer :price,               null: false
-      t.references :user,             null: false, foreign_key: true
+      t.string :name,                    null: false
+      t.text :text,                      null: false
+      t.integer :category_id,            null: false
+      t.integer :status_id,              null: false
+      t.integer :shipping_charges_id,    null: false
+      t.integer :shipping_origin_id,     null: false
+      t.integer :days_until_shipping_id, null: false
+      t.integer :price,                  null: false
+      t.references :user,                null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,11 +36,11 @@ ActiveRecord::Schema.define(version: 2020_09_13_053913) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "text", null: false
-    t.integer "category", null: false
-    t.integer "status", null: false
-    t.integer "shipping_charges", null: false
-    t.integer "shipping_origin", null: false
-    t.integer "days_until_shipping", null: false
+    t.integer "category_id", null: false
+    t.integer "status_id", null: false
+    t.integer "shipping_charges_id", null: false
+    t.integer "shipping_origin_id", null: false
+    t.integer "days_until_shipping_id", null: false
     t.integer "price", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :item do
     association :user
-    name                 { Faker::Games::Pokemon.name }
-    text                 { Faker::Lorem.sentence }
-    category             { Faker::Number.between(from: 1, to: 10) }
-    status               { Faker::Number.between(from: 1, to: 6) }
-    shipping_charges     { Faker::Number.between(from: 1, to: 2) }
-    shipping_origin      { Faker::Number.between(from: 1, to: 47) }
-    days_until_shipping  { Faker::Number.between(from: 1, to: 3) }
-    price                { Faker::Number.between(from: 300, to: 9_999_999) }
+    name                    { Faker::Games::Pokemon.name }
+    text                    { Faker::Lorem.sentence }
+    category_id             { Faker::Number.between(from: 1, to: 10) }
+    status_id               { Faker::Number.between(from: 1, to: 6) }
+    shipping_charges_id     { Faker::Number.between(from: 1, to: 2) }
+    shipping_origin_id      { Faker::Number.between(from: 1, to: 47) }
+    days_until_shipping_id  { Faker::Number.between(from: 1, to: 3) }
+    price                   { Faker::Number.between(from: 300, to: 9_999_999) }
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/item-sample.png'), filename: 'item-sample.png')

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -25,27 +25,27 @@ RSpec.describe Item, type: :model do
       expect(@item.errors.full_messages).to include("Text can't be blank")
     end
     it 'カテゴリーの情報が選択されていないと出品できない' do
-      @item.category = ''
+      @item.category_id = ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Category can't be blank")
     end
     it '商品の状態の情報が選択されていないと出品できない' do
-      @item.status = ''
+      @item.status_id= ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Status can't be blank")
     end
     it '配送料の負担の情報が選択されていないと出品できない' do
-      @item.shipping_charges = ''
+      @item.shipping_charges_id = ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Shipping charges can't be blank")
     end
     it '発送元の地域の情報が選択されていないと出品できない' do
-      @item.shipping_origin = ''
+      @item.shipping_origin_id = ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Shipping origin can't be blank")
     end
     it '発送までの日数の情報が選択されていないと出品できない' do
-      @item.days_until_shipping = ''
+      @item.days_until_shipping_id = ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Days until shipping can't be blank")
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Item, type: :model do
       expect(@item.errors.full_messages).to include("Category can't be blank")
     end
     it '商品の状態の情報が選択されていないと出品できない' do
-      @item.status_id= ''
+      @item.status_id = ''
       @item.valid?
       expect(@item.errors.full_messages).to include("Status can't be blank")
     end


### PR DESCRIPTION
# what
商品詳細表示機能の実装

# why
商品詳細表示機能を実装するため


出品者にしか商品の編集・削除のリンクが踏めないようになっていること、
商品出品時に登録した情報が見られるようになっていることのスクリーンショット
https://gyazo.com/4f519bd33babd693b6dafdb0c619484d

ログアウト状態でも商品詳細ページを閲覧できること、
出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めることのスクリーンショット
https://gyazo.com/533a4924acaf9507ea71ac4aad75103e